### PR TITLE
Add support for hostname

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,10 +13,10 @@ module.exports = {
 			{
 				type: 'textinput',
 				id: 'host',
-				label: 'IP Address',
+				label: 'IP Address / Hostname',
 				width: 6,
 				default: '192.168.0.1',
-				regex: Regex.IP,
+				regex: Regex.IP.slice(0, Regex.IP.length - 1) + '|' + Regex.HOSTNAME.slice(1, Regex.HOSTNAME.length),
 			},
 			{
 				type: 'dropdown',


### PR DESCRIPTION
Updated the regex validation to allow the use of hostname to connect to mixers that don't have a static IP address and are instead using a hostname. e.g. "mixer01.myoffice.local"